### PR TITLE
Update tic_tac_toe.rb

### DIFF
--- a/lib/tic_tac_toe.rb
+++ b/lib/tic_tac_toe.rb
@@ -57,9 +57,10 @@ def turn(board)
   input = gets.strip
   if !valid_move?(board, input)
     turn(board)
-  end
+  else
   move(board, input, current_player(board))
   display_board(board)
+  end
 end
 
 def position_taken?(board, location)


### PR DESCRIPTION
Within #turn, by using "else" instead of "end" you prevent the game from displaying duplicate boards in a row after an invalid move(s) followed by a valid move.
So if you have 3 invalid moves inputed in a row followed by a valid move, the game was displaying 4 boards.
This change seems to fix that.